### PR TITLE
Search parent directories for Makefile

### DIFF
--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -1,5 +1,6 @@
 shell = require 'shelljs'
 path = require 'path'
+fs = require 'fs-plus'
 
 module.exports =
 
@@ -28,10 +29,28 @@ module.exports =
   run: ->
     target = atom.config.get('make-runner.buildTarget')
 
+    # Get the path of the current file
+    editor = atom.workspace.activePaneItem
+    make_path = editor.getUri()
+
+    while not fs.existsSync "#{make_path}/Makefile"
+      console.log("#{make_path}/Makefile")
+      previous_path = make_path
+      make_path = path.join(make_path, '..')
+
+      if make_path == previous_path
+        @updateStatus "no makefile found"
+
+        setTimeout (=>
+          @clearStatus()
+        ), 3000
+
+        return
+
     if target?.length
-      cmd = "make #{target}"
+      cmd = "cd #{make_path} && make #{target}"
     else
-      cmd = 'make'
+      cmd = "cd #{make_path} && make"
 
     shell.cd atom.project.path
     shell.exec cmd, (code, output) =>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "shelljs": "^0.2.6"
+    "shelljs": "^0.2.6",
+    "fs-plus": "^2.0.4"
   }
 }


### PR DESCRIPTION
For use in slightly more complex project directory structures it would be nice to have the make runner search for a make file. This patch takes the path of the currently active editor pane, checks if it contains a `Makefile` - if not checks the parent directores (and repeat) - and runs make in the path where the `Makefile` was found.
