### PR TITLE
hide make output panel on success

### DIFF
--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -120,6 +120,10 @@ module.exports =
     make.on 'close',  (code) =>
       if code is 0
         @updateStatus 'succeeded'
+        if atom.config.get('make-runner.hidePane')
+          setTimeout (=>
+            @makeRunnerView.destroy()
+          ), atom.config.get('make-runner.hidePaneDelay')
       else
         @updateStatus "failed with code #{code}"
 
@@ -144,3 +148,12 @@ module.exports =
   #
   configDefaults:
     buildTarget: ''
+  config:
+    hidePane:
+      type: 'boolean'
+      default: false
+      description: 'Hide make panel if execution is successful.'
+    hidePaneDelay:
+      type: 'integer'
+      default: 3000
+      min:0


### PR DESCRIPTION
Adds two config options:
boolean to configure if the make panel is to be closed when make execution has successfully completed, and another to set the delay with which to close it.
