### PR TITLE
The original 'error' became the 'warning' marked with yellow.

### DIFF
--- a/lib/make-runner-view.coffee
+++ b/lib/make-runner-view.coffee
@@ -35,14 +35,19 @@ class MakeRunnerView extends View
 
     @canvas.append $("<div class='make-runner-#{type}'></div>").append line
 
-    if at_bottom
+    if at_bottom and not @had_error
       panel.scrollTop(panel[0].scrollHeight)
 
   printOutput: (line) ->
     @print line, 'output'
 
   printError: (line) ->
+    @had_error = true
     @print line, 'error'
 
+  printWarning: (line) ->
+    @print line, 'warning'
+
   clear: ->
+    @had_error = false
     @canvas.empty()

--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -52,6 +52,8 @@ module.exports =
     if @makeRunning
       return
 
+    @isError = false
+
     target = atom.config.get('make-runner.buildTarget')
 
     # figure out number of concurrent make jobs
@@ -114,7 +116,12 @@ module.exports =
           $('<span>').text errormessage
         ]
 
+        @isError = errormessage.indexOf(" error:") is 0
+
+      if @isError
       @makeRunnerView.printError html_line || line
+      else
+        @makeRunnerView.printWarning html_line || line
 
     # fire this off when the make process comes to an end
     make.on 'close',  (code) =>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Make runner for the Atom editor.",
   "author": "Matt Hernandez <matt@modulus.io>",
   "contributors": [
-    "Daniel Schwen <daniel@schwen.de> (http://www.schwen.de/)"
+    "Daniel Schwen <daniel@schwen.de> (http://www.schwen.de/)", 
+    "Sergey Egorov <egorovhome@gmail.com>"
   ],
   "private": true,
   "main": "lib/make-runner.coffee",

--- a/stylesheets/atom-make-runner.less
+++ b/stylesheets/atom-make-runner.less
@@ -13,6 +13,13 @@
     padding-left: 1em;
     border-left: 3px solid green;
   }
+  .make-runner-warning {
+    padding-left: 1em;
+    border-left: 3px solid orange;
+
+    // not pretty, but clang uses ascii-art to point at errors
+    font-family: monospace;
+  }
   .make-runner-error {
     padding-left: 1em;
     border-left: 3px solid red;


### PR DESCRIPTION
The original 'error' became the 'warning' marked with yellow. The output from stderr started by 'error:' threat as the 'error' and stops scroll at first error line.
