### PR TITLE
Hide on ESC, limit to editor panes

### DIFF
--- a/keymaps/make-runner.cson
+++ b/keymaps/make-runner.cson
@@ -1,3 +1,6 @@
-'atom-workspace':
+'atom-text-editor':
   'ctrl-r': 'make-runner:run'
   'ctrl-shift-r': 'make-runner:toggle'
+
+'atom-workspace':
+  'escape': 'make-runner:hide'

--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -13,8 +13,9 @@ module.exports =
   makeRunning: null
 
   #
-  # Make output pane
+  # Make output panel
   #
+  makeRunnerPanel: null
   makeRunnerView: null
 
   #
@@ -35,8 +36,9 @@ module.exports =
   # Attach the run command.
   #
   activate: (state) ->
-    atom.commands.add 'atom-workspace', 'make-runner:run', => @run()
-    atom.commands.add 'atom-workspace', 'make-runner:toggle', => @toggle()
+    atom.commands.add 'atom-text-editor', 'make-runner:run', => @run()
+    atom.commands.add 'atom-text-editor', 'make-runner:toggle', => @toggle()
+    atom.commands.add 'atom-workspace', 'make-runner:hide', => @makeRunnerPanel?.hide()
     @makeRunnerView = new MakeRunnerView(state.makeRunnerViewState)
     @makeRunnerPanel = atom.workspace.addBottomPanel(item: @makeRunnerView, visible: false, className: 'atom-make-runner tool-panel panel-bottom')
 


### PR DESCRIPTION
Pressing ```ctrl-R``` in the settings view threw an error. This patch limits the key-mapping to active editor panes (the package needs the path of the currently edited file to find the Makefile).

I also added a global key-mapping for ```ESC```. That key already hides stuff such as the find panes and it seems more intuitive to hide the make pane as well.

By the way, thanks for merging my stuff so quickly. I use the make runner on a day-to-day basis myself.