### PR TITLE
Fix StatusBar regression

### DIFF
--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -24,7 +24,7 @@ module.exports =
   updateStatus: (message) ->
     @statusBarTile?.destroy()
     statusBar = document.querySelector("status-bar")
-    @statusBarTile = statusBar?.addLeftTile(item: $ "<span id=\"make-runner\">Make: #{message}</span>", priority: 10)
+    @statusBarTile = statusBar?.addLeftTile(priority: 10, item: $ "<span>Make: #{message}</span>")
 
   #
   # Clear the make result from the status bar.


### PR DESCRIPTION
This fixes a bug where the ```priority``` property is actually passed to the ```$``` function call due to the way the coffeescript is compiled into JS. That meant that no ```priority``` property was present in the options passed to ```addLeftTile``` call, causing the status-bar package to throw an error (at seemingly random times).

Reordering the options object now produces the correct JS and should fix this bug. I've also removed the HTML id as we don't need it anymore.