### PR TITLE
Fix broken escape binding

### DIFF
--- a/keymaps/make-runner.cson
+++ b/keymaps/make-runner.cson
@@ -1,6 +1,3 @@
 'atom-text-editor':
   'ctrl-r': 'make-runner:run'
   'ctrl-shift-r': 'make-runner:toggle'
-
-'atom-workspace':
-  'escape': 'make-runner:hide'

--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -38,7 +38,7 @@ module.exports =
   activate: (state) ->
     atom.commands.add 'atom-text-editor', 'make-runner:run', => @run()
     atom.commands.add 'atom-text-editor', 'make-runner:toggle', => @toggle()
-    atom.commands.add 'atom-workspace', 'make-runner:hide', => @makeRunnerPanel?.hide()
+    atom.commands.add 'atom-workspace', 'core:cancel', => @makeRunnerPanel?.hide()
     @makeRunnerView = new MakeRunnerView(state.makeRunnerViewState)
     @makeRunnerPanel = atom.workspace.addBottomPanel(item: @makeRunnerView, visible: false, className: 'atom-make-runner tool-panel panel-bottom')
 


### PR DESCRIPTION
Adding a keymap binding will override the existing emission of the ```core:cancel``` event, effectively breaking the _escape_ to close find pane and command palette etc.

The way to do this correctly is to register the hide action to the ```core:cancel``` event. The broken escape behavior has bee driving me nuts and then I finally realized it was all my fault :-)