### PR TITLE
Arghhh, forgot the most important part for binding to atom-workspace.…

### DIFF
--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -36,8 +36,8 @@ module.exports =
   # Attach the run command.
   #
   activate: (state) ->
-    atom.commands.add 'atom-text-editor', 'make-runner:run', => @run()
-    atom.commands.add 'atom-text-editor', 'make-runner:toggle', => @toggle()
+    atom.commands.add 'atom-workspace', 'make-runner:run', => @run()
+    atom.commands.add 'atom-workspace', 'make-runner:toggle', => @toggle()
     atom.commands.add 'atom-workspace', 'core:cancel', => @makeRunnerPanel?.hide()
     @makeRunnerView = new MakeRunnerView state.makeRunnerViewState
     @makeRunnerPanel = atom.workspace.addBottomPanel(item: @makeRunnerView, visible: false, className: 'atom-make-runner tool-panel panel-bottom')


### PR DESCRIPTION
Sorry, I should have tested this better. This is the missing piece to have the make plugin react if just the tab handle has focus.