### PR TITLE
Q promise deprecation fix

### DIFF
--- a/lib/make-runner.coffee
+++ b/lib/make-runner.coffee
@@ -131,7 +131,7 @@ module.exports =
 
               # load file, but check if it is already open in any of the panes
               loading = atom.workspace.open file, { searchAllPanes: true }
-              loading.done (editor) =>
+              loading.then (editor) =>
                 editor.setCursorBufferPosition [row-1, col-1],
           $('<span>').text errormessage
         ]


### PR DESCRIPTION
This should get rid of a Deprecation Cop warning when clicking on a compiler error in the make output.