### PR TITLE
Target selector

### DIFF
--- a/lib/make-runner-target-list-view.coffee
+++ b/lib/make-runner-target-list-view.coffee
@@ -1,0 +1,33 @@
+{$$, SelectListView} = require 'atom-space-pen-views'
+
+module.exports =
+class ListView extends SelectListView
+  initialize: (@data, @onConfirm) ->
+    super
+    @addClass('make-runner-target')
+    @show()
+    targets = ({name} for name in @data)
+    @setItems(targets)
+    @focusFilterEditor()
+    @currentPane = atom.workspace.getActivePane()
+
+  getFilterKey: -> 'name'
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: -> @panel?.destroy()
+
+  viewForItem: ({name}) ->
+    $$ ->
+      @li name, =>
+        @div class: 'pull-right'
+
+  confirmed: (item) ->
+    @onConfirm(item)
+    @cancel()
+    @currentPane.activate() if @currentPane?.isAlive()

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "lib/make-runner.coffee",
   "activationCommands": {
     "atom-workspace": [
-      "make-runner:run"
+      "make-runner:run",
+      "make-runner:runTarget"
     ]
   },
   "repository": {


### PR DESCRIPTION
Adds a target selector to choose a valid make target:

![image](https://cloud.githubusercontent.com/assets/202302/25394751/2515fd6e-299c-11e7-9146-9e4cf031d5e1.png)

This runs make and obtains a list of valid targets. It supports arbitrarily complex makefiles (e.g. include directives that generate targets and variable targets).

Replaces #35 

**I'm putting this out here for comments. There is a little more work to do to correctly deal with abort and running make while the target list is obtained**